### PR TITLE
fix: gci version bypasses update cache for fresh check

### DIFF
--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -30,27 +30,40 @@ type updateCache struct {
 
 // StartUpdateCheck launches a background goroutine that checks for updates.
 // Returns a channel that will receive exactly one result.
+// Uses cached results when available to avoid hitting GitHub on every command.
 func StartUpdateCheck() <-chan UpdateCheckResult {
+	return startUpdateCheck(false)
+}
+
+// StartFreshUpdateCheck is like StartUpdateCheck but bypasses the cache,
+// always querying GitHub. Use this for explicit version checks.
+func StartFreshUpdateCheck() <-chan UpdateCheckResult {
+	return startUpdateCheck(true)
+}
+
+func startUpdateCheck(skipCache bool) <-chan UpdateCheckResult {
 	ch := make(chan UpdateCheckResult, 1)
 	go func() {
 		defer close(ch)
-		newVer := checkForUpdate(GetShortVersion())
+		newVer := checkForUpdate(GetShortVersion(), skipCache)
 		ch <- UpdateCheckResult{NewVersion: newVer}
 	}()
 	return ch
 }
 
-func checkForUpdate(current string) string {
+func checkForUpdate(current string, skipCache bool) string {
 	if current == "dev" {
 		return ""
 	}
 
 	// Try cache first — but invalidate if user has updated since last check
-	if cached, checkedVer, ok := loadUpdateCache(); ok && checkedVer == current {
-		if cached != "" && isNewerThan(cached, current) {
-			return cached
+	if !skipCache {
+		if cached, checkedVer, ok := loadUpdateCache(); ok && checkedVer == current {
+			if cached != "" && isNewerThan(cached, current) {
+				return cached
+			}
+			return ""
 		}
-		return ""
 	}
 
 	// Cache miss, stale, or user updated — query GitHub

--- a/internal/version/update_check_test.go
+++ b/internal/version/update_check_test.go
@@ -96,7 +96,7 @@ func TestCacheInvalidatedAfterUpdate(t *testing.T) {
 }
 
 func TestCheckForUpdate_DevBuild(t *testing.T) {
-	result := checkForUpdate("dev")
+	result := checkForUpdate("dev", false)
 	if result != "" {
 		t.Errorf("expected empty result for dev build, got %q", result)
 	}

--- a/main.go
+++ b/main.go
@@ -1980,8 +1980,8 @@ func runConfigDoctor(cmd *cobra.Command, args []string) {
 func runVersion(cmd *cobra.Command, args []string) {
 	fmt.Println(version.GetVersionString())
 
-	// Check for available updates (synchronous since user is asking about version)
-	ch := version.StartUpdateCheck()
+	// Check for available updates (fresh check since user explicitly asked)
+	ch := version.StartFreshUpdateCheck()
 	select {
 	case result := <-ch:
 		if result.NewVersion != "" {


### PR DESCRIPTION
## Summary
- `gci version` now always queries GitHub for the latest release instead of using the 24h cache
- Other commands (`board`, etc.) still use the cached check to avoid unnecessary API calls
- Fixes the issue where a newly published release wouldn't show in `gci version` output until the cache expired

## Test plan
- [x] `go build` passes
- [x] `go test ./internal/version/...` passes
- [ ] Install a release build, confirm `gci version` shows update notification when a newer release exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)