### PR TITLE
fix: security hardening and code quality improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ show_extra_fields = false
 - `branch_name_template` (kebab-case hardcoded)
 
 Notes:
-- Discovery results are cached at `~/.config/gci_boards_cache.json`.
+- Discovery results are cached at `~/.config/gci/boards_cache.json`.
 
 Loading order and fallbacks:
 - Runtime config (TOML) → env var overlays → `ErrNotConfigured` if no config exists.

--- a/board_tui.go
+++ b/board_tui.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"time"
 
@@ -317,13 +318,9 @@ func (m boardModel) filterAndGroupColumn(title string, all []JiraIssue, filter s
 		}
 	}
 	// Sort by score (highest first)
-	for i := 0; i < len(scored)-1; i++ {
-		for j := i + 1; j < len(scored); j++ {
-			if scored[j].score > scored[i].score {
-				scored[i], scored[j] = scored[j], scored[i]
-			}
-		}
-	}
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].score > scored[j].score
+	})
 	result := make([]JiraIssue, len(scored))
 	for i, s := range scored {
 		result[i] = s.issue

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -86,31 +86,13 @@ func NewJiraConnectionError(err error) *UserError {
 	}
 }
 
-func NewJQLPresetError(preset string, err error) *UserError {
-	return &UserError{
-		Title:       "❌ JQL Preset Error",
-		Message:     fmt.Sprintf("JQL preset '%s' failed to execute.", preset),
-		Remediation: "Check your JQL syntax in the config file. Run: gci config get jql_presets",
-		Cause:       err,
-	}
-}
-
-func NewJQLPresetNotFoundError(preset string) *UserError {
-	return &UserError{
-		Title:       "❌ JQL Preset Not Found",
-		Message:     fmt.Sprintf("JQL preset '%s' is not configured.", preset),
-		Remediation: "Run: gci config print to see available presets, or gci setup to configure them",
-		Cause:       nil,
-	}
-}
-
 func NewConfigError(operation string, err error) *UserError {
 	var remediation string
 	errStr := err.Error()
 	
 	switch {
 	case strings.Contains(errStr, "permission denied"):
-		remediation = "Check file permissions. Run: chmod 644 ~/.config/gci/config.toml"
+		remediation = "Check file permissions. Run: chmod 600 ~/.config/gci/config.toml"
 	case strings.Contains(errStr, "no such file"):
 		remediation = "Run: gci setup to create a configuration file"
 	case strings.Contains(errStr, "decode") || strings.Contains(errStr, "parse"):

--- a/internal/jira/discovery.go
+++ b/internal/jira/discovery.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -72,7 +73,7 @@ func getCacheFilePath() string {
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(homeDir, ".config", "gci_boards_cache.json")
+	return filepath.Join(homeDir, ".config", "gci", "boards_cache.json")
 }
 
 func loadFromCache(cacheFile string) ([]BoardWithActivity, bool) {
@@ -112,8 +113,8 @@ func saveToCache(cacheFile string, boards []BoardWithActivity) {
 		return
 	}
 
-	os.MkdirAll(filepath.Dir(cacheFile), 0755)
-	os.WriteFile(cacheFile, data, 0644)
+	os.MkdirAll(filepath.Dir(cacheFile), 0700)
+	os.WriteFile(cacheFile, data, 0600)
 }
 
 // FetchBoardsFromAPI is an exported wrapper for testing
@@ -317,15 +318,13 @@ func RankBoards(boards []Board, currentProjects []string) []Board {
 		}{board, score}
 	}
 
-	// Sort by score (deterministic - uses board ID as tiebreaker for consistency)
-	for i := 0; i < len(scored)-1; i++ {
-		for j := i + 1; j < len(scored); j++ {
-			if scored[i].score < scored[j].score || 
-			   (scored[i].score == scored[j].score && scored[i].board.ID > scored[j].board.ID) {
-				scored[i], scored[j] = scored[j], scored[i]
-			}
+	// Sort by score descending (deterministic - uses board ID as tiebreaker for consistency)
+	sort.Slice(scored, func(i, j int) bool {
+		if scored[i].score != scored[j].score {
+			return scored[i].score > scored[j].score
 		}
-	}
+		return scored[i].board.ID < scored[j].board.ID
+	})
 
 	result := make([]Board, len(scored))
 	for i, s := range scored {

--- a/internal/jira/discovery_test.go
+++ b/internal/jira/discovery_test.go
@@ -1,6 +1,8 @@
 package jira
 
 import (
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -103,7 +105,7 @@ func TestGetCacheFilePath(t *testing.T) {
 		t.Skip("No home directory available")
 	}
 	
-	if len(path) < 21 || path[len(path)-21:] != "gci_boards_cache.json" {
-		t.Errorf("Cache file path should end with gci_boards_cache.json, got %s", path)
+	if !strings.HasSuffix(path, filepath.Join("gci", "boards_cache.json")) {
+		t.Errorf("Cache file path should end with gci/boards_cache.json, got %s", path)
 	}
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -86,11 +86,11 @@ func getDebugLogFile() *os.File {
 	}
 	
 	logPath := filepath.Join(home, ".config", "gci_debug.log")
-	if err := os.MkdirAll(filepath.Dir(logPath), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(logPath), 0700); err != nil {
 		return nil
 	}
-	
-	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+
+	file, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		return nil
 	}

--- a/internal/usercfg/config.go
+++ b/internal/usercfg/config.go
@@ -121,11 +121,11 @@ func Save(config Config) error {
 	}
 
 	configDir := filepath.Dir(configPath)
-	if err := os.MkdirAll(configDir, 0755); err != nil {
+	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return fmt.Errorf("failed to create config directory: %v", err)
 	}
 
-	file, err := os.Create(configPath)
+	file, err := os.OpenFile(configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create config file: %v", err)
 	}

--- a/internal/version/update_check.go
+++ b/internal/version/update_check.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -99,10 +100,17 @@ func checkForUpdate(current string, skipCache bool) string {
 	return latestVer
 }
 
+// envMu serialises access to GITHUB_TOKEN so the temporary unset/restore
+// in NewPublicGitHubSource cannot race with concurrent goroutines.
+var envMu sync.Mutex
+
 // NewPublicGitHubSource creates a GitHubSource that ignores any
 // GITHUB_TOKEN in the environment. gci's repo is public and never
 // needs auth; a stale token would cause a 401.
 func NewPublicGitHubSource() (*selfupdate.GitHubSource, error) {
+	envMu.Lock()
+	defer envMu.Unlock()
+
 	token := os.Getenv("GITHUB_TOKEN")
 	if token != "" {
 		os.Unsetenv("GITHUB_TOKEN")
@@ -179,6 +187,6 @@ func saveUpdateCacheTo(path string, latestVersion, checkedVersion string) {
 		return
 	}
 
-	os.MkdirAll(filepath.Dir(path), 0755)
-	os.WriteFile(path, data, 0644)
+	os.MkdirAll(filepath.Dir(path), 0700)
+	os.WriteFile(path, data, 0600)
 }

--- a/main.go
+++ b/main.go
@@ -331,14 +331,7 @@ func loadConfig() (*Config, error) {
 
 	// Guard: require configuration
 	if userConfig.JiraURL == "" || len(userConfig.Projects) == 0 {
-		fmt.Println("GCI is not configured yet.")
-		fmt.Println()
-		fmt.Println("Run:  gci setup")
-		fmt.Println()
-		fmt.Println("Or set environment variables:")
-		fmt.Println("  GCI_JIRA_URL=https://your-company.atlassian.net")
-		fmt.Println("  GCI_PROJECTS=PROJ1,PROJ2")
-		os.Exit(1)
+		return nil, fmt.Errorf("GCI is not configured yet.\n\nRun:  gci setup\n\nOr set environment variables:\n  GCI_JIRA_URL=https://your-company.atlassian.net\n  GCI_PROJECTS=PROJ1,PROJ2")
 	}
 
 	// Get email from git config
@@ -620,7 +613,8 @@ func spawnClaudeWithContext(worktreePath string, issue JiraIssue) error {
 		issue.Fields.Summary,
 		description)
 
-	cmd := exec.Command("claude", prompt)
+	// Use "--" to prevent JIRA content from being interpreted as flags
+	cmd := exec.Command("claude", "--", prompt)
 	cmd.Dir = worktreePath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -1287,43 +1281,9 @@ func getFieldsList() string {
 
 // fetchColumnIssues fetches up to maxResults issues for a given statusCategory + scope
 func fetchColumnIssues(config *Config, statusCategory string, scope scopeFilter, maxResults int) ([]JiraIssue, error) {
-	projectFilter := buildProjectFilter(config.Projects)
-	scopePredicate := buildScopePredicate(scope)
-
-	var predicates []string
-	predicates = append(predicates, projectFilter)
-	predicates = append(predicates, fmt.Sprintf("statusCategory = \"%s\"", statusCategory))
-	if scopePredicate != "" {
-		predicates = append(predicates, scopePredicate)
-	}
-	jql := strings.Join(predicates, " AND ") + " ORDER BY updated DESC"
-
 	ctx, cancel := context.WithTimeout(context.Background(), httputil.DefaultTimeout)
 	defer cancel()
-	
-	client := httputil.NewDefaultClient()
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/rest/api/3/search/jql", config.JiraURL), nil)
-	if err != nil {
-		return nil, err
-	}
-	req.SetBasicAuth(config.Email, config.APIToken)
-	req.Header.Set("Accept", "application/json")
-	q := req.URL.Query()
-	q.Add("jql", jql)
-	q.Add("maxResults", fmt.Sprintf("%d", maxResults))
-	q.Add("fields", getFieldsList())
-	req.URL.RawQuery = q.Encode()
-
-	logger.HTTP("GET", req.URL.String())
-	
-	var jiraResp JiraResponse
-	if err := client.DoJSONRequest(ctx, req, &jiraResp); err != nil {
-		logger.JIRA("request failed: %v", err)
-		return nil, errors.WrapWithContext(err, "jira_connection")
-	}
-	
-	logger.JIRA("Fetched %d issues for statusCategory=%q scope=%q", len(jiraResp.Issues), statusCategory, scopeToString(scope))
-	return jiraResp.Issues, nil
+	return fetchColumnIssuesWithContext(ctx, config, statusCategory, scope, maxResults)
 }
 
 // fetchColumnIssuesWithContext fetches column issues with a provided context for cancellation
@@ -2044,11 +2004,4 @@ func runUpdate(cmd *cobra.Command, args []string) {
 	}
 
 	fmt.Printf("Updated to %s\n", latest.Version())
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }


### PR DESCRIPTION
## Summary

- **Fix data race** — GITHUB_TOKEN env var was unset/restored without synchronisation during update checks; serialised with a mutex
- **Fix flag injection** — JIRA issue content passed as a Claude CLI arg could contain flags; now uses `--` separator
- **Restrict file permissions** — Config/cache/log files changed from 0644 → 0600 (owner-only)
- **Consistent cache path** — Board cache moved from `~/.config/gci_boards_cache.json` to `~/.config/gci/boards_cache.json`
- **Remove dead code** — JQL preset error constructors deleted (feature was removed)
- **Deduplicate JIRA fetch** — `fetchColumnIssues` now delegates to its context-aware variant instead of duplicating ~35 lines
- **Fix `loadConfig` exit** — Returns an error instead of calling `os.Exit(1)` directly
- **Replace O(n²) sorts** — Bubble sorts replaced with `sort.Slice`
- **Remove shadowed `min()`** — Go 1.21+ provides this builtin natively

## Test plan

- [ ] `go build` passes
- [ ] `go test ./...` passes
- [ ] `go vet ./...` clean