### PR TITLE
fix: gci config doctor verifies JIRA auth and surfaces real 401 cause

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,7 +69,7 @@ func NewJiraConnectionError(err error) *UserError {
 	var remediation string
 	
 	if strings.Contains(errStr, "401") || strings.Contains(errStr, "Unauthorized") {
-		remediation = "Your Atlassian API token is rejected (often expired — Atlassian ages tokens out automatically). Create a new classic (unscoped) token at https://id.atlassian.com/manage-profile/security/api-tokens, store it in 1Password, then verify with: gci config doctor"
+		remediation = "Atlassian rejected your API token. Create a new classic (unscoped) token at https://id.atlassian.com/manage-profile/security/api-tokens, update your token source, then run: gci config doctor"
 	} else if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "no such host") {
 		remediation = "Check your internet connection and JIRA URL. Run: gci config doctor"
 	} else if strings.Contains(errStr, "403") || strings.Contains(errStr, "Forbidden") {
@@ -142,7 +142,7 @@ func NewHttpError(statusCode int, body string) *UserError {
 	switch {
 	case statusCode == 401:
 		title = "❌ Authentication Failed"
-		remediation = "Your Atlassian API token is rejected (often expired — Atlassian ages tokens out automatically). Create a new classic (unscoped) token at https://id.atlassian.com/manage-profile/security/api-tokens, store it in 1Password, then verify with: gci config doctor"
+		remediation = "Atlassian rejected your API token. Create a new classic (unscoped) token at https://id.atlassian.com/manage-profile/security/api-tokens, update your token source, then run: gci config doctor"
 	case statusCode == 403:
 		title = "❌ Access Forbidden" 
 		remediation = "Your account lacks permission for this operation. Contact your JIRA administrator"

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -69,7 +69,7 @@ func NewJiraConnectionError(err error) *UserError {
 	var remediation string
 	
 	if strings.Contains(errStr, "401") || strings.Contains(errStr, "Unauthorized") {
-		remediation = "Check your API token in 1Password. Run: op signin && gci config doctor"
+		remediation = "Your Atlassian API token is rejected (often expired — Atlassian ages tokens out automatically). Create a new classic (unscoped) token at https://id.atlassian.com/manage-profile/security/api-tokens, store it in 1Password, then verify with: gci config doctor"
 	} else if strings.Contains(errStr, "timeout") || strings.Contains(errStr, "no such host") {
 		remediation = "Check your internet connection and JIRA URL. Run: gci config doctor"
 	} else if strings.Contains(errStr, "403") || strings.Contains(errStr, "Forbidden") {
@@ -142,7 +142,7 @@ func NewHttpError(statusCode int, body string) *UserError {
 	switch {
 	case statusCode == 401:
 		title = "❌ Authentication Failed"
-		remediation = "Check your API token. Run: op signin && gci config doctor"
+		remediation = "Your Atlassian API token is rejected (often expired — Atlassian ages tokens out automatically). Create a new classic (unscoped) token at https://id.atlassian.com/manage-profile/security/api-tokens, store it in 1Password, then verify with: gci config doctor"
 	case statusCode == 403:
 		title = "❌ Access Forbidden" 
 		remediation = "Your account lacks permission for this operation. Contact your JIRA administrator"

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -124,7 +124,7 @@ func TestNewJiraConnectionError(t *testing.T) {
 		{
 			name:           "401 unauthorized",
 			cause:          fmt.Errorf("HTTP 401: Unauthorized"),
-			expectedRemediation: "API token is rejected",
+			expectedRemediation: "rejected your API token",
 		},
 		{
 			name:           "timeout error",
@@ -165,7 +165,7 @@ func TestNewHttpError(t *testing.T) {
 		expectedTitle    string
 		expectedRemediation string
 	}{
-		{401, "❌ Authentication Failed", "API token is rejected"},
+		{401, "❌ Authentication Failed", "rejected your API token"},
 		{403, "❌ Access Forbidden", "Your account lacks permission"},
 		{404, "❌ Resource Not Found", "The requested JIRA resource was not found"},
 		{500, "❌ Server Error", "JIRA server is experiencing issues"},

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -124,7 +124,7 @@ func TestNewJiraConnectionError(t *testing.T) {
 		{
 			name:           "401 unauthorized",
 			cause:          fmt.Errorf("HTTP 401: Unauthorized"),
-			expectedRemediation: "Check your API token",
+			expectedRemediation: "API token is rejected",
 		},
 		{
 			name:           "timeout error",
@@ -165,7 +165,7 @@ func TestNewHttpError(t *testing.T) {
 		expectedTitle    string
 		expectedRemediation string
 	}{
-		{401, "❌ Authentication Failed", "Check your API token"},
+		{401, "❌ Authentication Failed", "API token is rejected"},
 		{403, "❌ Access Forbidden", "Your account lacks permission"},
 		{404, "❌ Resource Not Found", "The requested JIRA resource was not found"},
 		{500, "❌ Server Error", "JIRA server is experiencing issues"},

--- a/main.go
+++ b/main.go
@@ -2088,11 +2088,11 @@ func runConfigDoctor(cmd *cobra.Command, args []string) {
 				fmt.Printf("✅ JIRA authentication OK (%s, token from %s)\n", email, tokenSource)
 			case authProbeUnauthorized:
 				fmt.Printf("❌ JIRA returned 401 for %s (token from %s)\n", email, tokenSource)
-				fmt.Println("   The API token is rejected. Atlassian ages tokens out automatically;")
-				fmt.Println("   tokens issued before 2024-12-15 expire between 2026-03-14 and 2026-05-12.")
+				fmt.Println("   Atlassian rejected the token. Common cause: expiry — Atlassian assigns")
+				fmt.Println("   expiry dates to API tokens automatically.")
 				fmt.Println("   Create a new classic (unscoped) token at:")
 				fmt.Println("     https://id.atlassian.com/manage-profile/security/api-tokens")
-				fmt.Println("   then update the value in 1Password and re-run: gci config doctor")
+				fmt.Println("   then update your token source and re-run: gci config doctor")
 				issues++
 			case authProbeForbidden:
 				fmt.Printf("❌ JIRA returned 403 for %s (token from %s)\n", email, tokenSource)

--- a/main.go
+++ b/main.go
@@ -459,6 +459,9 @@ func probeJiraAuth(jiraURL, email, token string) authProbeResult {
 		return authProbeResult{Status: authProbeNetworkError, Email: email, Detail: err.Error()}
 	}
 	defer resp.Body.Close()
+	// Drain the body so the transport can return the connection to the pool;
+	// idiomatic even though this short-lived diagnostic client does not reuse it.
+	io.Copy(io.Discard, resp.Body)
 
 	switch resp.StatusCode {
 	case http.StatusOK:
@@ -496,29 +499,13 @@ func resolveJiraCreds(userConfig usercfg.Config) (email, token, tokenSource stri
 	return email, "", "no token source configured"
 }
 
-// isJiraTokenValid checks if the given email/token can authenticate to Jira by calling /myself
+// isJiraTokenValid checks if the given email/token can authenticate to Jira by calling /myself.
+// It delegates to probeJiraAuth so the actual HTTP probe logic lives in one place.
 func isJiraTokenValid(jiraURL, email, token string) bool {
-	if jiraURL == "" || email == "" || token == "" {
+	if jiraURL == "" {
 		return false
 	}
-	
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	
-	client := httputil.NewRetryableClient(5*time.Second, 1) // Quick validation, minimal retries
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/rest/api/3/myself", jiraURL), nil)
-	if err != nil {
-		return false
-	}
-	req.SetBasicAuth(email, token)
-	req.Header.Set("Accept", "application/json")
-	
-	resp, err := client.DoWithRetry(ctx, req)
-	if err != nil {
-		return false
-	}
-	defer resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
+	return probeJiraAuth(jiraURL, email, token).Status == authProbeOK
 }
 
 // fetchJiraEmail calls /rest/api/3/myself and returns the account's email address.

--- a/main.go
+++ b/main.go
@@ -410,6 +410,92 @@ func loadConfig() (*Config, error) {
 	}, nil
 }
 
+// authProbeStatus is the outcome of a /myself authentication probe.
+type authProbeStatus int
+
+const (
+	authProbeOK authProbeStatus = iota
+	authProbeNoToken
+	authProbeNoEmail
+	authProbeUnauthorized // 401 — token rejected (often expired)
+	authProbeForbidden    // 403 — token authenticated but lacks permission
+	authProbeNetworkError
+	authProbeUnexpectedStatus
+)
+
+// authProbeResult carries the outcome plus details for a useful diagnostic.
+type authProbeResult struct {
+	Status     authProbeStatus
+	StatusCode int    // HTTP status when reached the server, else 0
+	Email      string // resolved email actually used
+	Detail     string // free-form context (network error, response snippet, etc.)
+}
+
+// probeJiraAuth issues GET /rest/api/3/myself with HTTP Basic auth (with at
+// most one retry on transient network errors). It returns a structured result
+// rather than an error so callers can render distinct remediation guidance
+// per failure mode.
+func probeJiraAuth(jiraURL, email, token string) authProbeResult {
+	if token == "" {
+		return authProbeResult{Status: authProbeNoToken}
+	}
+	if email == "" {
+		return authProbeResult{Status: authProbeNoEmail}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := httputil.NewRetryableClient(5*time.Second, 1)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/rest/api/3/myself", jiraURL), nil)
+	if err != nil {
+		return authProbeResult{Status: authProbeNetworkError, Email: email, Detail: err.Error()}
+	}
+	req.SetBasicAuth(email, token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.DoWithRetry(ctx, req)
+	if err != nil {
+		return authProbeResult{Status: authProbeNetworkError, Email: email, Detail: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return authProbeResult{Status: authProbeOK, StatusCode: resp.StatusCode, Email: email}
+	case http.StatusUnauthorized:
+		return authProbeResult{Status: authProbeUnauthorized, StatusCode: resp.StatusCode, Email: email}
+	case http.StatusForbidden:
+		return authProbeResult{Status: authProbeForbidden, StatusCode: resp.StatusCode, Email: email}
+	default:
+		return authProbeResult{Status: authProbeUnexpectedStatus, StatusCode: resp.StatusCode, Email: email}
+	}
+}
+
+// resolveJiraCreds returns the email and API token gci would use at runtime,
+// applying the same precedence as loadConfig (env > 1Password) without its
+// os.Exit guard. tokenSource describes where the token came from for logging.
+func resolveJiraCreds(userConfig usercfg.Config) (email, token, tokenSource string) {
+	if out, err := exec.Command("git", "config", "user.email").Output(); err == nil {
+		email = strings.TrimSpace(string(out))
+		for oldDomain, newDomain := range userConfig.EmailDomainMap {
+			email = strings.Replace(email, oldDomain, newDomain, 1)
+		}
+	}
+
+	if envToken := os.Getenv("JIRA_API_TOKEN"); envToken != "" {
+		return email, envToken, "JIRA_API_TOKEN env var"
+	}
+	if userConfig.OPJiraTokenPath != "" {
+		out, err := exec.Command("op", "read", userConfig.OPJiraTokenPath).Output()
+		if err == nil {
+			return email, strings.TrimSpace(string(out)), "1Password (" + userConfig.OPJiraTokenPath + ")"
+		}
+		return email, "", "1Password (" + userConfig.OPJiraTokenPath + ") — op read failed: " + err.Error()
+	}
+	return email, "", "no token source configured"
+}
+
 // isJiraTokenValid checks if the given email/token can authenticate to Jira by calling /myself
 func isJiraTokenValid(jiraURL, email, token string) bool {
 	if jiraURL == "" || email == "" || token == "" {
@@ -1967,6 +2053,7 @@ func runConfigDoctor(cmd *cobra.Command, args []string) {
 	}
 
 	// Check JIRA URL
+	jiraURLValid := false
 	if config.JiraURL == "" {
 		fmt.Println("⚠️  JIRA URL not configured")
 		fmt.Println("   Run: gci setup")
@@ -1977,6 +2064,53 @@ func runConfigDoctor(cmd *cobra.Command, args []string) {
 		issues++
 	} else {
 		fmt.Printf("✅ JIRA URL configured: %s\n", config.JiraURL)
+		jiraURLValid = true
+	}
+
+	// Live authentication probe — the previous doctor never actually verified
+	// credentials, so an expired/revoked token produced "all healthy" reports
+	// while every API call returned 401.
+	if jiraURLValid {
+		email, token, tokenSource := resolveJiraCreds(config)
+		switch {
+		case token == "":
+			fmt.Printf("⚠️  Could not resolve a JIRA API token (%s)\n", tokenSource)
+			fmt.Println("   Set JIRA_API_TOKEN or configure op_jira_token_path; then run: gci setup")
+			issues++
+		case email == "":
+			fmt.Println("⚠️  Could not resolve an email for JIRA auth")
+			fmt.Println("   Set git config user.email and re-run: gci config doctor")
+			issues++
+		default:
+			result := probeJiraAuth(config.JiraURL, email, token)
+			switch result.Status {
+			case authProbeOK:
+				fmt.Printf("✅ JIRA authentication OK (%s, token from %s)\n", email, tokenSource)
+			case authProbeUnauthorized:
+				fmt.Printf("❌ JIRA returned 401 for %s (token from %s)\n", email, tokenSource)
+				fmt.Println("   The API token is rejected. Atlassian ages tokens out automatically;")
+				fmt.Println("   tokens issued before 2024-12-15 expire between 2026-03-14 and 2026-05-12.")
+				fmt.Println("   Create a new classic (unscoped) token at:")
+				fmt.Println("     https://id.atlassian.com/manage-profile/security/api-tokens")
+				fmt.Println("   then update the value in 1Password and re-run: gci config doctor")
+				issues++
+			case authProbeForbidden:
+				fmt.Printf("❌ JIRA returned 403 for %s (token from %s)\n", email, tokenSource)
+				fmt.Println("   The token authenticated but lacks permission for /myself.")
+				fmt.Println("   If you used a scoped token, gci needs a classic (unscoped) one.")
+				issues++
+			case authProbeNetworkError:
+				fmt.Printf("⚠️  Could not reach %s: %s\n", config.JiraURL, result.Detail)
+				fmt.Println("   Check your network and the configured jira_url.")
+				issues++
+			case authProbeUnexpectedStatus:
+				fmt.Printf("⚠️  JIRA returned HTTP %d (unexpected)\n", result.StatusCode)
+				issues++
+			default:
+				fmt.Printf("⚠️  Unexpected auth probe status: %d (HTTP %d)\n", result.Status, result.StatusCode)
+				issues++
+			}
+		}
 	}
 
 	fmt.Println()


### PR DESCRIPTION
## Summary

`gci config doctor` previously reported "all healthy" even when the configured JIRA token was expired or revoked — every real API call would then return 401. This adds a **live authentication probe** and rewrites the 401 remediation copy to point at the actual fix.

## Changes

- **Live auth probe in `config doctor`** — issues `GET /rest/api/3/myself` with the credentials gci would actually use at runtime, and renders distinct guidance per failure mode (401 token rejected / 403 lacks permission / network error / unexpected status). Only runs when the JIRA URL is valid.
  - `probeJiraAuth` — structured-result probe (mirrors the existing `isJiraTokenValid`, same endpoint and 5s/1-retry client, honors a 5s context deadline).
  - `resolveJiraCreds` — resolves email + token with the same precedence as `loadConfig` (git email + `email_domain_map`, then `JIRA_API_TOKEN` env → 1Password `op read`), but without the `os.Exit` guard so the doctor can report instead of exiting.
- **Tighter 401 remediation copy** in `internal/errors` — directs users to create a new *classic (unscoped)* Atlassian API token (the common cause is auto-assigned token expiry), instead of the vague "check your API token."
- Updated `errors_test.go` expectations to match the new copy.

## Verification

- `go build -o gci .` — OK
- `go vet ./...` — OK
- `go test ./...` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)